### PR TITLE
Feature: Add API Key Tooltips and Refine Provider UI

### DIFF
--- a/docs/vertex.md
+++ b/docs/vertex.md
@@ -1,0 +1,50 @@
+# Vertex AI Imagen API Reference (Image Generation)
+
+This document summarizes key details for generating images using the Vertex AI Imagen API endpoint (`https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}:predict`).
+
+**Note:** This API typically requires Google Cloud authentication (gcloud, service accounts) and is distinct from the Gemini API endpoint (`generativelanguage.googleapis.com`) which uses API keys.
+
+## Supported Models (Examples)
+
+*   `imagen-3.0-generate-002`
+*   `imagen-3.0-generate-001`
+*   `imagen-3.0-fast-generate-001`
+*   `imagegeneration@006`
+*   `imagegeneration@005`
+*   `imagegeneration@002`
+
+*(Refer to official Vertex AI documentation for the complete and latest list)*
+
+## Key Request Parameters (`parameters` object)
+
+Based on the REST API reference for `imagegeneration` models (as of May 2025):
+
+| Parameter         | Type    | Description                                                                                                                               | Supported Models (Examples)                                                                                                |
+|-------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `prompt`          | string  | **Required.** Text description of the desired image. Max token length varies by model (e.g., 480 for Imagen 3, 128 for @006, 64 for @002). | All                                                                                                                        |
+| `sampleCount`     | integer | **Required.** Number of images to generate (Default: 4). Max varies by model (e.g., 4 for Imagen 3 & @006, 8 for @002).                     | All                                                                                                                        |
+| `negativePrompt`  | string  | Optional. A description of what to discourage in the generated images. Max token length varies by model.                                  | Most (e.g., `imagen-3.0-generate-001`, `@006`, `@005`, `@002`). *Note: Docs state `imagen-3.0-generate-002` doesn't support.* |
+| `seed`            | integer | Optional. Random seed (positive integer) for reproducibility. Not usable if `addWatermark` is true.                                       | All                                                                                                                        |
+| `aspectRatio`     | string  | Optional. Aspect ratio (e.g., "1:1", "16:9", "9:16", "4:3", "3:4"). Default: "1:1". Support varies by model.                               | Most (e.g., Imagen 3, @006 support all common ratios; @005 supports "1:1", "9:16"; @002 supports "1:1")                   |
+| `personGeneration`| string  | Optional. Control generation of people ("dont_allow", "allow_adult", "allow_all"). Default: "allow_adult".                                | Newer models (e.g., Imagen 3, @006)                                                                                        |
+| `addWatermark`    | boolean | Optional. Add SynthID watermark. Default varies (true for Imagen 3/@006, false for @005/@002). Cannot use `seed` if true.                   | All                                                                                                                        |
+| `enhancePrompt`   | boolean | Optional. Use LLM to rewrite prompt for better quality. Default: true.                                                                      | `imagen-3.0-generate-002`                                                                                                  |
+| `language`        | string  | Optional. Language code of the prompt (e.g., "en", "es", "ja", "auto"). Default: "auto".                                                  | Newer models (e.g., Imagen 3, @006)                                                                                        |
+| `safetySetting`   | string  | Optional. Safety filter level ("block_none", "block_only_high", "block_medium_and_above", "block_low_and_above"). Default: "block_medium_and_above". | Newer models (e.g., Imagen 3, @006)                                                                                        |
+| `outputOptions`   | object  | Optional. Contains `mimeType` ("image/png", "image/jpeg") and `compressionQuality` (0-100 for JPEG).                                      | All                                                                                                                        |
+| `storageUri`      | string  | Optional. Cloud Storage URI to store images instead of returning base64 bytes.                                                            | All                                                                                                                        |
+| `sampleImageStyle`| string  | Optional. Predefined style ("photograph", "digital_art", "sketch", etc.).                                                                 | `imagegeneration@002` only                                                                                                 |
+
+**Note:** Parameters like `guidanceScale` and `stylePreset` (as a general list) were not explicitly listed in the REST API reference table consulted, although they might be available via SDKs or specific model versions not detailed on that page.
+
+## Response Body (`predictions` array)
+
+Each object in the `predictions` array typically contains:
+
+*   `bytesBase64Encoded`: The base64 encoded image data (if not filtered and `storageUri` not used).
+*   `mimeType`: The image MIME type (e.g., "image/png").
+*   `raiFilteredReason`: Reason if the image was filtered by safety settings.
+*   `safetyAttributes`: Scores for different safety categories (if requested).
+*   `prompt`: The enhanced prompt used by the model (if `enhancePrompt` was enabled).
+
+*(Refer to the official Vertex AI PredictResponse documentation for full details)*

--- a/index.html
+++ b/index.html
@@ -21,9 +21,13 @@
                     <input type="radio" id="provider-google" name="provider" value="google">
                     <label for="provider-google">Google Imagen</label>
                 </div>
-                <div class="provider-option">
-                    <input type="radio" id="provider-vertex-ai" name="provider" value="vertex-ai">
-                    <label for="provider-vertex-ai">Google Vertex AI (UI Only)</label>
+                <div class="provider-option disabled">
+                    <input type="radio" id="provider-vertex-ai" name="provider" value="vertex-ai" disabled>
+                    <label for="provider-vertex-ai" class="disabled-label">Google Vertex AI</label>
+                    <span class="tooltip-icon" id="vertex-tooltip-trigger">ⓘ</span>
+                    <div id="vertex-tooltip" class="tooltip" style="display: none;">
+                        Full Vertex AI support with advanced parameters requires a different setup (e.g., SaaS version). Not available in this playground.
+                    </div>
                 </div>
                 <div class="provider-option disabled">
                     <input type="radio" id="provider-adobe" name="provider" value="adobe" disabled>
@@ -167,52 +171,7 @@
                 </div>
             </div>
 
-            <!-- Vertex AI Specific Options (UI Only) -->
-            <div id="vertex-ai-options-container" class="vertex-ai-option" style="display: none;">
-                <h3>Vertex AI Options (Not Functional)</h3>
-                <div class="options">
-                    <div class="option-item">
-                        <label for="vertex_negative_prompt">Negative Prompt:</label>
-                        <textarea id="vertex_negative_prompt" rows="2" placeholder="Enter elements to exclude..."></textarea>
-                        <p class="option-description">Vertex AI only. Describe what you *don't* want.</p>
-                    </div>
-                    <div class="option-item">
-                        <label for="vertex_seed">Seed:</label>
-                        <input type="number" id="vertex_seed" placeholder="Leave blank for random">
-                        <p class="option-description">Vertex AI only. Integer for reproducible results.</p>
-                    </div>
-                    <div class="option-item">
-                        <label for="vertex_guidance_scale">Guidance Scale:</label>
-                        <input type="number" id="vertex_guidance_scale" value="7.0" min="1" max="20" step="0.5">
-                        <p class="option-description">Vertex AI only. Prompt adherence (1-20).</p>
-                    </div>
-                    <div class="option-item">
-                        <label for="vertex_style_preset">Style Preset:</label>
-                        <select id="vertex_style_preset">
-                            <option value="" selected>None</option>
-                            <option value="photographic">Photographic</option>
-                            <option value="digital-art">Digital Art</option>
-                            <option value="cinematic">Cinematic</option>
-                            <option value="anime">Anime</option>
-                            <option value="painterly">Painterly</option>
-                            <option value="pixel-art">Pixel Art</option>
-                            <option value="fantasy">Fantasy</option>
-                            <option value="neon">Neon</option>
-                            <option value="isometric">Isometric</option>
-                            <option value="dystopian">Dystopian</option>
-                            <option value="steampunk">Steampunk</option>
-                            <option value="minimalist">Minimalist</option>
-                            <option value="origami">Origami</option>
-                            <option value="watercolor">Watercolor</option>
-                            <option value="retrowave">Retrowave</option>
-                            <option value="3d-model">3D Model</option>
-                        </select>
-                        <p class="option-description">Vertex AI only. Apply a visual style.</p>
-                    </div>
-                    <!-- Add other Vertex AI specific params here if needed -->
-                </div>
-                <p id="vertex-status-message" style="color: orange; margin-top: 10px;">Note: Vertex AI generation is not implemented. These controls are for UI demonstration only.</p>
-            </div>
+
 
             <button id="generate-button">Generate Image</button>
         </section>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                     <select id="n">
                         <!-- Options populated by JS -->
                     </select>
-                    <p class="option-description">How many images to generate (1-10). DALL-E 3 only supports 1.</p>
+                    <p class="option-description" id="n-description">How many images to generate (1-10). DALL-E 3 only supports 1.</p>
                  </div>
 
                 <!-- DALL-E 3 Specific Options -->

--- a/index.html
+++ b/index.html
@@ -35,13 +35,21 @@
         <section id="api-key-section">
             <h2>API Keys</h2>
             <div id="openai-key-section">
-                <label for="openai-api-key">OpenAI API Key:</label>
+                <label for="openai-api-key">OpenAI API Key: <span class="tooltip-icon" id="openai-key-tooltip-trigger">ⓘ</span>
+                    <div id="openai-key-tooltip" class="tooltip" style="display: none;">
+                        Create an OpenAI API key at <a href="https://platform.openai.com/api-keys" target="_blank">https://platform.openai.com/api-keys</a>
+                    </div>
+                </label>
                 <input type="password" id="openai-api-key" placeholder="sk-...">
                 <button id="save-openai-key-button">Save Key</button>
                 <p id="openai-key-status">Status: No key saved.</p>
             </div>
             <div id="google-key-section" style="display: none;">
-                <label for="google-api-key">Google API Key:</label>
+                <label for="google-api-key">Google API Key: <span class="tooltip-icon" id="google-key-tooltip-trigger">ⓘ</span>
+                    <div id="google-key-tooltip" class="tooltip" style="display: none;">
+                        Create a Google API key at <a href="https://aistudio.google.com/app/apikey" target="_blank">https://aistudio.google.com/app/apikey</a>
+                    </div>
+                </label>
                 <input type="password" id="google-api-key" placeholder="...">
                 <button id="save-google-key-button">Save Key</button>
                 <p id="google-key-status">Status: No key saved.</p>

--- a/index.html
+++ b/index.html
@@ -153,6 +153,44 @@
                     <p class="option-description">Google Imagen only. The aspect ratio of the generated image.</p>
                 </div>
                 <div class="option-item google-imagen-option" style="display: none;">
+                    <label for="negative_prompt">Negative Prompt:</label>
+                    <textarea id="negative_prompt" rows="2" placeholder="Enter elements to exclude..."></textarea>
+                    <p class="option-description">Google Imagen only. Describe what you *don't* want in the image.</p>
+                </div>
+                <div class="option-item google-imagen-option" style="display: none;">
+                    <label for="seed">Seed:</label>
+                    <input type="number" id="seed" placeholder="Leave blank for random">
+                    <p class="option-description">Google Imagen only. Integer for reproducible results.</p>
+                </div>
+                <div class="option-item google-imagen-option" style="display: none;">
+                    <label for="guidance_scale">Guidance Scale:</label>
+                    <input type="number" id="guidance_scale" value="7.0" min="1" max="20" step="0.5">
+                    <p class="option-description">Google Imagen only. How strongly the prompt guides generation (1-20).</p>
+                </div>
+                <div class="option-item google-imagen-option" style="display: none;">
+                    <label for="style_preset">Style Preset:</label>
+                    <select id="style_preset">
+                        <option value="" selected>None</option>
+                        <option value="photographic">Photographic</option>
+                        <option value="digital-art">Digital Art</option>
+                        <option value="cinematic">Cinematic</option>
+                        <option value="anime">Anime</option>
+                        <option value="painterly">Painterly</option>
+                        <option value="pixel-art">Pixel Art</option>
+                        <option value="fantasy">Fantasy</option>
+                        <option value="neon">Neon</option>
+                        <option value="isometric">Isometric</option>
+                        <option value="dystopian">Dystopian</option>
+                        <option value="steampunk">Steampunk</option>
+                        <option value="minimalist">Minimalist</option>
+                        <option value="origami">Origami</option>
+                        <option value="watercolor">Watercolor</option>
+                        <option value="retrowave">Retrowave</option>
+                        <option value="3d-model">3D Model</option>
+                    </select>
+                    <p class="option-description">Google Imagen only. Apply a specific visual style.</p>
+                </div>
+                <div class="option-item google-imagen-option" style="display: none;">
                     <label for="person_generation">Person Generation:</label>
                     <select id="person_generation">
                         <option value="ALLOW_ADULT" selected>Allow Adults</option>

--- a/index.html
+++ b/index.html
@@ -152,44 +152,7 @@
                     </select>
                     <p class="option-description">Google Imagen only. The aspect ratio of the generated image.</p>
                 </div>
-                <div class="option-item google-imagen-option" style="display: none;">
-                    <label for="negative_prompt">Negative Prompt:</label>
-                    <textarea id="negative_prompt" rows="2" placeholder="Enter elements to exclude..."></textarea>
-                    <p class="option-description">Google Imagen only. Describe what you *don't* want in the image.</p>
-                </div>
-                <div class="option-item google-imagen-option" style="display: none;">
-                    <label for="seed">Seed:</label>
-                    <input type="number" id="seed" placeholder="Leave blank for random">
-                    <p class="option-description">Google Imagen only. Integer for reproducible results.</p>
-                </div>
-                <div class="option-item google-imagen-option" style="display: none;">
-                    <label for="guidance_scale">Guidance Scale:</label>
-                    <input type="number" id="guidance_scale" value="7.0" min="1" max="20" step="0.5">
-                    <p class="option-description">Google Imagen only. How strongly the prompt guides generation (1-20).</p>
-                </div>
-                <div class="option-item google-imagen-option" style="display: none;">
-                    <label for="style_preset">Style Preset:</label>
-                    <select id="style_preset">
-                        <option value="" selected>None</option>
-                        <option value="photographic">Photographic</option>
-                        <option value="digital-art">Digital Art</option>
-                        <option value="cinematic">Cinematic</option>
-                        <option value="anime">Anime</option>
-                        <option value="painterly">Painterly</option>
-                        <option value="pixel-art">Pixel Art</option>
-                        <option value="fantasy">Fantasy</option>
-                        <option value="neon">Neon</option>
-                        <option value="isometric">Isometric</option>
-                        <option value="dystopian">Dystopian</option>
-                        <option value="steampunk">Steampunk</option>
-                        <option value="minimalist">Minimalist</option>
-                        <option value="origami">Origami</option>
-                        <option value="watercolor">Watercolor</option>
-                        <option value="retrowave">Retrowave</option>
-                        <option value="3d-model">3D Model</option>
-                    </select>
-                    <p class="option-description">Google Imagen only. Apply a specific visual style.</p>
-                </div>
+
                 <div class="option-item google-imagen-option" style="display: none;">
                     <label for="person_generation">Person Generation:</label>
                     <select id="person_generation">

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
                     <input type="radio" id="provider-google" name="provider" value="google">
                     <label for="provider-google">Google Imagen</label>
                 </div>
+                <div class="provider-option">
+                    <input type="radio" id="provider-vertex-ai" name="provider" value="vertex-ai">
+                    <label for="provider-vertex-ai">Google Vertex AI (UI Only)</label>
+                </div>
                 <div class="provider-option disabled">
                     <input type="radio" id="provider-adobe" name="provider" value="adobe" disabled>
                     <label for="provider-adobe" class="disabled-label">Adobe Firefly (Coming Soon)</label>
@@ -161,6 +165,53 @@
                     </select>
                     <p class="option-description">Google Imagen only. Controls whether people can be generated in images.</p>
                 </div>
+            </div>
+
+            <!-- Vertex AI Specific Options (UI Only) -->
+            <div id="vertex-ai-options-container" class="vertex-ai-option" style="display: none;">
+                <h3>Vertex AI Options (Not Functional)</h3>
+                <div class="options">
+                    <div class="option-item">
+                        <label for="vertex_negative_prompt">Negative Prompt:</label>
+                        <textarea id="vertex_negative_prompt" rows="2" placeholder="Enter elements to exclude..."></textarea>
+                        <p class="option-description">Vertex AI only. Describe what you *don't* want.</p>
+                    </div>
+                    <div class="option-item">
+                        <label for="vertex_seed">Seed:</label>
+                        <input type="number" id="vertex_seed" placeholder="Leave blank for random">
+                        <p class="option-description">Vertex AI only. Integer for reproducible results.</p>
+                    </div>
+                    <div class="option-item">
+                        <label for="vertex_guidance_scale">Guidance Scale:</label>
+                        <input type="number" id="vertex_guidance_scale" value="7.0" min="1" max="20" step="0.5">
+                        <p class="option-description">Vertex AI only. Prompt adherence (1-20).</p>
+                    </div>
+                    <div class="option-item">
+                        <label for="vertex_style_preset">Style Preset:</label>
+                        <select id="vertex_style_preset">
+                            <option value="" selected>None</option>
+                            <option value="photographic">Photographic</option>
+                            <option value="digital-art">Digital Art</option>
+                            <option value="cinematic">Cinematic</option>
+                            <option value="anime">Anime</option>
+                            <option value="painterly">Painterly</option>
+                            <option value="pixel-art">Pixel Art</option>
+                            <option value="fantasy">Fantasy</option>
+                            <option value="neon">Neon</option>
+                            <option value="isometric">Isometric</option>
+                            <option value="dystopian">Dystopian</option>
+                            <option value="steampunk">Steampunk</option>
+                            <option value="minimalist">Minimalist</option>
+                            <option value="origami">Origami</option>
+                            <option value="watercolor">Watercolor</option>
+                            <option value="retrowave">Retrowave</option>
+                            <option value="3d-model">3D Model</option>
+                        </select>
+                        <p class="option-description">Vertex AI only. Apply a visual style.</p>
+                    </div>
+                    <!-- Add other Vertex AI specific params here if needed -->
+                </div>
+                <p id="vertex-status-message" style="color: orange; margin-top: 10px;">Note: Vertex AI generation is not implemented. These controls are for UI demonstration only.</p>
             </div>
 
             <button id="generate-button">Generate Image</button>

--- a/plan.md
+++ b/plan.md
@@ -139,7 +139,7 @@ Create a no-code, mobile-optimized web application that allows users to generate
         *   Define Google Imagen model options and parameters in the `modelOptions` object in `script.js`.
         *   Create API endpoint constants for Google Imagen API.
         *   Implement the API call function for Google Imagen similar to the OpenAI implementation.
-        *   Add basic Google Imagen parameters (Negative Prompt, Seed, Guidance Scale, Style Preset).
+        *   Add basic Google Imagen parameters supported by the Gemini API endpoint (Aspect Ratio, Person Generation). (Note: Negative Prompt, Seed, Guidance Scale, Style Preset were found to be unsupported for the `imagen-3.0-generate-002` model via the Gemini API and were removed).
     *   Implement API key management for multiple providers:
         *   Modify the API key section to support multiple providers.
         *   Create separate input fields and storage for OpenAI and Google API keys.

--- a/plan.md
+++ b/plan.md
@@ -128,44 +128,36 @@ Create a no-code, mobile-optimized web application that allows users to generate
     *   Add radio buttons at the top of the UI for different image generation providers:
         *   OpenAI models (DALL-E 2, DALL-E 3, GPT-Image-1)
         *   Google Imagen (via Gemini API)
-        *   Google Vertex AI (UI Placeholder)
-        *   Adobe Firefly models
+        *   Google Vertex AI (Disabled Placeholder)
+        *   Adobe Firefly models (Disabled Placeholder)
     *   Implement the UI changes:
         *   Create a new section in `index.html` above the model selection dropdown for provider selection.
         *   Style the provider selection section with radio buttons in `style.css`.
-        *   Grey out Adobe Firefly option (not yet supported) with appropriate styling and tooltip.
-        *   Add a placeholder "Google Vertex AI (UI Only)" provider option.
+        *   Grey out Adobe Firefly and Google Vertex AI options, making them unclickable.
+        *   Add tooltips to disabled providers explaining their status (e.g., Vertex AI requires different setup/SaaS version).
         *   Update the model dropdown to dynamically show only models from the selected *functional* provider (OpenAI, Google Imagen).
     *   Implement Google Imagen API integration (Gemini Endpoint):
-        *   Add support for Google Imagen API using the Gemini API endpoint (`generativelanguage.googleapis.com`).
-        *   Define Google Imagen model options and parameters supported by this endpoint (`aspectRatio`, `personGeneration`) in `modelOptions`.
-        *   Create API endpoint constants for the Gemini API Imagen endpoint.
-        *   Implement the API call function for Google Imagen via Gemini API.
-        *   (Note: Negative Prompt, Seed, Guidance Scale, Style Preset were found to be unsupported for the `imagen-3.0-generate-002` model via the Gemini API).
+        *   Use the Gemini API endpoint (`generativelanguage.googleapis.com`) for the "Google Imagen" provider.
+        *   Define the `imagen-3.0-generate-002` model and its supported parameters (`aspectRatio`, `personGeneration`, `numberOfImages`) in `modelOptions`.
+        *   Implement the API call function using the user's Google API Key.
+        *   (Note: Parameters like Negative Prompt, Seed, etc., are *not* supported by this endpoint for Imagen 3).
     *   Implement API key management for multiple providers:
-        *   Modify the API key section to support multiple providers (OpenAI, Google).
-        *   Create separate input fields and storage for OpenAI and Google API keys.
-        *   Update the `localStorage` key names to be provider-specific.
-        *   Modify the key loading and saving functions to handle multiple providers.
-        *   Hide API key inputs when Vertex AI provider is selected (as it uses different auth).
+        *   Modify the API key section to support OpenAI and Google API keys.
+        *   Show the relevant API key input based on the selected functional provider.
+        *   Hide API key inputs when a disabled provider (Vertex AI, Adobe) is selected.
     *   Update the image generation logic:
         *   Modify the generate button event listener to check which provider is selected.
         *   Route the API call to the appropriate provider's API endpoint (OpenAI, Google Imagen).
-        *   Disable generation button when Vertex AI provider is selected.
+        *   Disable generation button when a disabled provider is selected.
         *   Handle provider-specific response formats and error messages.
     *   Add provider-specific UI elements and options:
-        *   Create container divs for Google Imagen (Gemini API) specific options.
-        *   Create container divs for Google Vertex AI specific options (UI only).
-        *   Update the `updateProviderUI` function to show/hide provider-specific options and API key sections.
-        *   Ensure all provider-specific parameters are correctly included in API requests for functional providers.
+        *   Create container divs for Google Imagen (Gemini API) specific options (`aspectRatio`, `personGeneration`).
+        *   Update the `updateProviderUI` and `updateOptionsUI` functions to show/hide provider-specific options and API key sections correctly.
+        *   Remove any non-functional UI elements previously added for Vertex AI.
     *   **Future Enhancements (Deferred):**
-        *   **Vertex AI Implementation:** Fully implement Vertex AI generation. This likely requires a backend proxy server to handle Google Cloud authentication securely and make API calls to the `aiplatform.googleapis.com` endpoint. Define Vertex AI models (`imagegeneration@001`, `@002`, `@003`, etc.) and their parameters (`negativePrompt`, `seed`, etc.) in `modelOptions`.
-        *   **Imagen Model Versions (Gemini API):** If different Imagen models become available via the Gemini API endpoint with different parameters, update `modelOptions` and UI logic.
+        *   **Vertex AI Implementation:** Fully implement Vertex AI generation. This likely requires a backend proxy server to handle Google Cloud authentication securely and make API calls to the `aiplatform.googleapis.com` endpoint. Define Vertex AI models (`imagegeneration@001`, `@002`, `@003`, etc.) and their parameters (`negativePrompt`, `seed`, etc.) in `modelOptions` and add corresponding UI controls.
         *   **Imagen Editing Modes (Vertex AI):** Implement advanced Imagen capabilities like Image-to-Image, Inpainting, Outpainting via the Vertex AI API (requires backend and UI changes).
-        *   **Imagen Region/Endpoint (Vertex AI):** Allow user selection of Google Cloud region and update the Vertex AI API endpoint accordingly (requires backend).
-        *   **Imagen Width/Height (Vertex AI):** Add explicit width/height inputs for Vertex AI.
-        *   **Imagen Minor Params (Vertex AI):** Add UI controls for less common Vertex AI parameters.
-        *   **Imagen Response Metadata (Vertex AI):** Display metadata returned by the Vertex AI API.
+        *   **Adobe Firefly Implementation:** Add support when feasible.
 
 ## Considerations
 -   **API Costs:** Clearly inform users that generating images incurs costs on their OpenAI account.

--- a/plan.md
+++ b/plan.md
@@ -124,7 +124,7 @@ Create a no-code, mobile-optimized web application that allows users to generate
         *   Ensure that when moving/copying, the images retain their `src` (URL or base64 data URI).
         *   Consider adding functionality to clear the camera roll or limit the number of stored images if `localStorage` usage becomes a concern (optional enhancement).
 
-11. **Add Multi-Provider Support:**
+11. **Add Multi-Provider Support & Advanced Imagen Features:**
     *   Add radio buttons at the top of the UI for different image generation providers:
         *   OpenAI models (DALL-E 2, DALL-E 3, GPT-Image-1)
         *   Google Imagen models
@@ -135,10 +135,11 @@ Create a no-code, mobile-optimized web application that allows users to generate
         *   Grey out Adobe Firefly option (not yet supported) with appropriate styling and tooltip.
         *   Update the model dropdown to dynamically show only models from the selected provider.
     *   Implement Google Imagen API integration:
-        *   Add support for Google Imagen API using the Gemini API (https://ai.google.dev/gemini-api/docs/image-generation).
+        *   Add support for Google Imagen API using the Vertex AI Imagen endpoint (or Gemini API if preferred).
         *   Define Google Imagen model options and parameters in the `modelOptions` object in `script.js`.
-        *   Create a new API endpoint constant for Google Imagen API.
+        *   Create API endpoint constants for Google Imagen API.
         *   Implement the API call function for Google Imagen similar to the OpenAI implementation.
+        *   Add basic Google Imagen parameters (Negative Prompt, Seed, Guidance Scale, Style Preset).
     *   Implement API key management for multiple providers:
         *   Modify the API key section to support multiple providers.
         *   Create separate input fields and storage for OpenAI and Google API keys.
@@ -152,6 +153,13 @@ Create a no-code, mobile-optimized web application that allows users to generate
         *   Create container divs for Google Imagen specific options.
         *   Update the `updateOptionsUI` function to show/hide provider-specific options.
         *   Ensure all provider-specific parameters are correctly included in API requests.
+    *   **Future Enhancements (Deferred):**
+        *   **Imagen Model Versions:** Support multiple Imagen model versions (e.g., `imagegeneration@002`, `@003`) by updating `modelOptions`, allowing selection in the UI, and dynamically changing the API endpoint in `script.js`.
+        *   **Imagen Editing Modes:** Implement advanced Imagen capabilities like Image-to-Image, Inpainting, Outpainting, and Conditional Generation. This requires significant UI additions for image uploads, masking tools, etc.
+        *   **Imagen Region/Endpoint:** Allow user selection of Google Cloud region (`us-central1`, etc.) and update the API endpoint accordingly.
+        *   **Imagen Width/Height:** Add explicit width/height inputs as an alternative or complement to aspect ratio.
+        *   **Imagen Minor Params:** Add UI controls for less common parameters like `dynamicThreshold`, `noiseLevel`, `stepCount`, `quality`.
+        *   **Imagen Response Metadata:** Display metadata returned by the API (e.g., seed used, safety ratings, generation time) in the UI.
 
 ## Considerations
 -   **API Costs:** Clearly inform users that generating images incurs costs on their OpenAI account.

--- a/plan.md
+++ b/plan.md
@@ -127,39 +127,45 @@ Create a no-code, mobile-optimized web application that allows users to generate
 11. **Add Multi-Provider Support & Advanced Imagen Features:**
     *   Add radio buttons at the top of the UI for different image generation providers:
         *   OpenAI models (DALL-E 2, DALL-E 3, GPT-Image-1)
-        *   Google Imagen models
+        *   Google Imagen (via Gemini API)
+        *   Google Vertex AI (UI Placeholder)
         *   Adobe Firefly models
     *   Implement the UI changes:
         *   Create a new section in `index.html` above the model selection dropdown for provider selection.
         *   Style the provider selection section with radio buttons in `style.css`.
         *   Grey out Adobe Firefly option (not yet supported) with appropriate styling and tooltip.
-        *   Update the model dropdown to dynamically show only models from the selected provider.
-    *   Implement Google Imagen API integration:
-        *   Add support for Google Imagen API using the Vertex AI Imagen endpoint (or Gemini API if preferred).
-        *   Define Google Imagen model options and parameters in the `modelOptions` object in `script.js`.
-        *   Create API endpoint constants for Google Imagen API.
-        *   Implement the API call function for Google Imagen similar to the OpenAI implementation.
-        *   Add basic Google Imagen parameters supported by the Gemini API endpoint (Aspect Ratio, Person Generation). (Note: Negative Prompt, Seed, Guidance Scale, Style Preset were found to be unsupported for the `imagen-3.0-generate-002` model via the Gemini API and were removed).
+        *   Add a placeholder "Google Vertex AI (UI Only)" provider option.
+        *   Update the model dropdown to dynamically show only models from the selected *functional* provider (OpenAI, Google Imagen).
+    *   Implement Google Imagen API integration (Gemini Endpoint):
+        *   Add support for Google Imagen API using the Gemini API endpoint (`generativelanguage.googleapis.com`).
+        *   Define Google Imagen model options and parameters supported by this endpoint (`aspectRatio`, `personGeneration`) in `modelOptions`.
+        *   Create API endpoint constants for the Gemini API Imagen endpoint.
+        *   Implement the API call function for Google Imagen via Gemini API.
+        *   (Note: Negative Prompt, Seed, Guidance Scale, Style Preset were found to be unsupported for the `imagen-3.0-generate-002` model via the Gemini API).
     *   Implement API key management for multiple providers:
-        *   Modify the API key section to support multiple providers.
+        *   Modify the API key section to support multiple providers (OpenAI, Google).
         *   Create separate input fields and storage for OpenAI and Google API keys.
-        *   Update the `localStorage` key names to be provider-specific (e.g., `openai_api_key`, `google_api_key`).
+        *   Update the `localStorage` key names to be provider-specific.
         *   Modify the key loading and saving functions to handle multiple providers.
+        *   Hide API key inputs when Vertex AI provider is selected (as it uses different auth).
     *   Update the image generation logic:
         *   Modify the generate button event listener to check which provider is selected.
-        *   Route the API call to the appropriate provider's API endpoint.
+        *   Route the API call to the appropriate provider's API endpoint (OpenAI, Google Imagen).
+        *   Disable generation button when Vertex AI provider is selected.
         *   Handle provider-specific response formats and error messages.
     *   Add provider-specific UI elements and options:
-        *   Create container divs for Google Imagen specific options.
-        *   Update the `updateOptionsUI` function to show/hide provider-specific options.
-        *   Ensure all provider-specific parameters are correctly included in API requests.
+        *   Create container divs for Google Imagen (Gemini API) specific options.
+        *   Create container divs for Google Vertex AI specific options (UI only).
+        *   Update the `updateProviderUI` function to show/hide provider-specific options and API key sections.
+        *   Ensure all provider-specific parameters are correctly included in API requests for functional providers.
     *   **Future Enhancements (Deferred):**
-        *   **Imagen Model Versions:** Support multiple Imagen model versions (e.g., `imagegeneration@002`, `@003`) by updating `modelOptions`, allowing selection in the UI, and dynamically changing the API endpoint in `script.js`.
-        *   **Imagen Editing Modes:** Implement advanced Imagen capabilities like Image-to-Image, Inpainting, Outpainting, and Conditional Generation. This requires significant UI additions for image uploads, masking tools, etc.
-        *   **Imagen Region/Endpoint:** Allow user selection of Google Cloud region (`us-central1`, etc.) and update the API endpoint accordingly.
-        *   **Imagen Width/Height:** Add explicit width/height inputs as an alternative or complement to aspect ratio.
-        *   **Imagen Minor Params:** Add UI controls for less common parameters like `dynamicThreshold`, `noiseLevel`, `stepCount`, `quality`.
-        *   **Imagen Response Metadata:** Display metadata returned by the API (e.g., seed used, safety ratings, generation time) in the UI.
+        *   **Vertex AI Implementation:** Fully implement Vertex AI generation. This likely requires a backend proxy server to handle Google Cloud authentication securely and make API calls to the `aiplatform.googleapis.com` endpoint. Define Vertex AI models (`imagegeneration@001`, `@002`, `@003`, etc.) and their parameters (`negativePrompt`, `seed`, etc.) in `modelOptions`.
+        *   **Imagen Model Versions (Gemini API):** If different Imagen models become available via the Gemini API endpoint with different parameters, update `modelOptions` and UI logic.
+        *   **Imagen Editing Modes (Vertex AI):** Implement advanced Imagen capabilities like Image-to-Image, Inpainting, Outpainting via the Vertex AI API (requires backend and UI changes).
+        *   **Imagen Region/Endpoint (Vertex AI):** Allow user selection of Google Cloud region and update the Vertex AI API endpoint accordingly (requires backend).
+        *   **Imagen Width/Height (Vertex AI):** Add explicit width/height inputs for Vertex AI.
+        *   **Imagen Minor Params (Vertex AI):** Add UI controls for less common Vertex AI parameters.
+        *   **Imagen Response Metadata (Vertex AI):** Display metadata returned by the Vertex AI API.
 
 ## Considerations
 -   **API Costs:** Clearly inform users that generating images incurs costs on their OpenAI account.

--- a/script.js
+++ b/script.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const nInput = document.getElementById('n');
     const generateButton = document.getElementById('generate-button');
     const statusMessage = document.getElementById('status-message');
+    const nDescription = document.getElementById('n-description');
     const imageResultDiv = document.getElementById('image-result');
 
     // Model Specific Option Containers & Controls
@@ -247,6 +248,21 @@ document.addEventListener('DOMContentLoaded', () => {
             nSelect.value = 1;
         }
         nSelect.disabled = options.maxN === 1; // Disable dropdown if only 1 option
+
+        // Update N description
+        if (nDescription) {
+            let descriptionText = `How many images to generate (1-${options.maxN}).`;
+            if (selectedModel === 'dall-e-3') {
+                descriptionText += " DALL-E 3 only supports 1.";
+            } else if (options.provider === 'google') {
+                descriptionText += ` Google Imagen supports 1-${options.maxN}.`;
+            } else if (selectedModel === 'gpt-image-1') {
+                 descriptionText += ` Max ${options.maxN}.`;
+            } else if (selectedModel === 'dall-e-2') {
+                 descriptionText += ` Max ${options.maxN}.`;
+            }
+            nDescription.textContent = descriptionText;
+        }
 
         // Show/Hide OpenAI Model Specific Sections
         dalle3OptionsDiv.style.display = options.supportsStyle ? 'block' : 'none';

--- a/script.js
+++ b/script.js
@@ -46,6 +46,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const googleImagenOptions = document.querySelectorAll('.google-imagen-option');
     const aspectRatioSelect = document.getElementById('aspect_ratio');
     const personGenerationSelect = document.getElementById('person_generation');
+    const negativePromptInput = document.getElementById('negative_prompt');
+    const seedInput = document.getElementById('seed');
+    const guidanceScaleInput = document.getElementById('guidance_scale');
+    const stylePresetSelect = document.getElementById('style_preset');
 
     // API Constants
     const OPENAI_API_KEY_NAME = 'openai_api_key';
@@ -557,6 +561,27 @@ document.addEventListener('DOMContentLoaded', () => {
         // Add person generation parameter if not default
         if (personGenerationSelect.value !== 'ALLOW_ADULT') {
             requestBody.parameters.personGeneration = personGenerationSelect.value;
+        }
+
+        // Add negative prompt if provided
+        const negativePrompt = negativePromptInput.value.trim();
+        if (negativePrompt) {
+            requestBody.parameters.negativePrompt = negativePrompt;
+        }
+
+        // Add seed if provided
+        const seed = parseInt(seedInput.value);
+        if (!isNaN(seed)) {
+            requestBody.parameters.seed = seed;
+        }
+
+        // Add guidance scale (always include, use default from input)
+        requestBody.parameters.guidanceScale = parseFloat(guidanceScaleInput.value) || 7.0;
+
+        // Add style preset if selected
+        const stylePreset = stylePresetSelect.value;
+        if (stylePreset) {
+            requestBody.parameters.stylePreset = stylePreset;
         }
 
         console.log('Sending request to Google Imagen:', JSON.stringify(requestBody, null, 2));

--- a/script.js
+++ b/script.js
@@ -47,6 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const aspectRatioSelect = document.getElementById('aspect_ratio');
     const personGenerationSelect = document.getElementById('person_generation');
 
+    const vertexAiOptionsContainer = document.getElementById('vertex-ai-options-container');
 
     // API Constants
     const OPENAI_API_KEY_NAME = 'openai_api_key';
@@ -119,32 +120,58 @@ document.addEventListener('DOMContentLoaded', () => {
     function updateProviderUI(selectedProvider) {
         console.log(`Updating UI for provider: ${selectedProvider}`);
         
-        // Show/hide API key sections based on provider
+        // Show/hide API key sections and Vertex options
         openaiKeySection.style.display = selectedProvider === 'openai' ? 'block' : 'none';
         googleKeySection.style.display = selectedProvider === 'google' ? 'block' : 'none';
-        
-        // Filter and show only models for the selected provider
-        const options = modelSelect.querySelectorAll('option');
-        let firstVisibleOption = null;
-        
-        options.forEach(option => {
-            const modelName = option.value;
-            const modelConfig = modelOptions[modelName];
-            
-            if (modelConfig && modelConfig.provider === selectedProvider) {
-                option.style.display = '';
-                if (!firstVisibleOption) {
-                    firstVisibleOption = option;
+        vertexAiOptionsContainer.style.display = selectedProvider === 'vertex-ai' ? 'block' : 'none';
+
+        // Enable/disable generate button and clear status
+        if (selectedProvider === 'vertex-ai') {
+            generateButton.disabled = true;
+            generateButton.textContent = 'Generate Image (Vertex AI N/A)';
+            statusMessage.textContent = 'Vertex AI provider selected (UI Only - Generation Disabled).';
+            statusMessage.style.color = 'orange';
+            modelSelect.innerHTML = '<option value="">-- Vertex AI Models Not Implemented --</option>'; // Clear models
+            modelSelect.disabled = true;
+            // Hide all standard model options
+            document.querySelectorAll('.options .option-item').forEach(el => el.style.display = 'none');
+        } else {
+            generateButton.disabled = false;
+            generateButton.textContent = 'Generate Image';
+            statusMessage.textContent = ''; // Clear status message
+            modelSelect.disabled = false;
+
+            // Filter and show only models for the selected provider (OpenAI or Google)
+            const options = modelSelect.querySelectorAll('option');
+            let firstVisibleOption = null;
+            modelSelect.innerHTML = ''; // Clear previous options before adding new ones
+
+            Object.keys(modelOptions).forEach(modelName => {
+                const modelConfig = modelOptions[modelName];
+                if (modelConfig.provider === selectedProvider) {
+                    const option = document.createElement('option');
+                    option.value = modelName;
+                    option.textContent = modelName;
+                    // Add back classes if needed, e.g., for Google models
+                    if (selectedProvider === 'google') {
+                         option.classList.add('google-model');
+                    }
+                    modelSelect.appendChild(option);
+                    if (!firstVisibleOption) {
+                        firstVisibleOption = option;
+                    }
                 }
+            });
+
+            // Select the first visible option and update UI
+            if (firstVisibleOption) {
+                modelSelect.value = firstVisibleOption.value;
+                updateOptionsUI(firstVisibleOption.value);
             } else {
-                option.style.display = 'none';
+                 modelSelect.innerHTML = '<option value="">-- No models available --</option>';
+                 // Hide all standard model options if no models found
+                 document.querySelectorAll('.options .option-item').forEach(el => el.style.display = 'none');
             }
-        });
-        
-        // Select the first visible option
-        if (firstVisibleOption) {
-            modelSelect.value = firstVisibleOption.value;
-            updateOptionsUI(firstVisibleOption.value);
         }
     }
 

--- a/script.js
+++ b/script.js
@@ -7,7 +7,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const adobeTooltipTrigger = document.getElementById('adobe-tooltip-trigger');
     const adobeTooltip = document.getElementById('adobe-tooltip');
     
+
     // API Keys
+    // API Key Tooltips
+    const openaiKeyTooltipTrigger = document.getElementById('openai-key-tooltip-trigger');
+    const openaiKeyTooltip = document.getElementById('openai-key-tooltip');
+    const googleKeyTooltipTrigger = document.getElementById('google-key-tooltip-trigger');
+    const googleKeyTooltip = document.getElementById('google-key-tooltip');
     const openaiApiKeyInput = document.getElementById('openai-api-key');
     const saveOpenaiKeyButton = document.getElementById('save-openai-key-button');
     const openaiKeyStatus = document.getElementById('openai-key-status');
@@ -240,14 +246,53 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
     
-    // Adobe Firefly tooltip
-    adobeTooltipTrigger.addEventListener('mouseover', () => {
-        adobeTooltip.style.display = 'block';
-    });
-    
-    adobeTooltipTrigger.addEventListener('mouseout', () => {
-        adobeTooltip.style.display = 'none';
-    });
+
+
+    // --- Tooltip Hide Delay Logic ---
+    let hideTimeout;
+
+    function showTooltip(tooltipElement) {
+        clearTimeout(hideTimeout);
+        tooltipElement.style.display = 'block';
+    }
+
+    function hideTooltip(tooltipElement) {
+        hideTimeout = setTimeout(() => {
+            tooltipElement.style.display = 'none';
+        }, 100); // Delay hiding slightly
+    }
+
+    // Helper to add listeners
+    function addTooltipListeners(triggerElement, tooltipElement) {
+        if (triggerElement && tooltipElement) {
+            console.log(`Attaching tooltip listeners for: ${tooltipElement.id}`);
+            triggerElement.addEventListener('mouseover', () => {
+                console.log(`${tooltipElement.id} - trigger mouseover`);
+                showTooltip(tooltipElement);
+            });
+            triggerElement.addEventListener('mouseout', () => {
+                console.log(`${tooltipElement.id} - trigger mouseout`);
+                hideTooltip(tooltipElement);
+            });
+            tooltipElement.addEventListener('mouseover', () => {
+                console.log(`${tooltipElement.id} - tooltip mouseover`);
+                clearTimeout(hideTimeout); // Cancel hide if mouse enters tooltip
+            });
+            tooltipElement.addEventListener('mouseout', () => {
+                console.log(`${tooltipElement.id} - tooltip mouseout`);
+                hideTooltip(tooltipElement); // Hide when mouse leaves tooltip too
+            });
+        } else {
+            console.warn(`Tooltip elements not found for trigger/tooltip pair.`);
+        }
+    }
+
+    // Add listeners for specific tooltips
+    addTooltipListeners(openaiKeyTooltipTrigger, openaiKeyTooltip);
+    addTooltipListeners(googleKeyTooltipTrigger, googleKeyTooltip);
+    addTooltipListeners(adobeTooltipTrigger, adobeTooltip); // Apply to Adobe too for consistency
+
+
     
     // Update UI when model changes
     modelSelect.addEventListener('change', (e) => {

--- a/script.js
+++ b/script.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const googleKeySection = document.getElementById('google-key-section');
     const adobeTooltipTrigger = document.getElementById('adobe-tooltip-trigger');
     const adobeTooltip = document.getElementById('adobe-tooltip');
+    const vertexTooltipTrigger = document.getElementById('vertex-tooltip-trigger');
+    const vertexTooltip = document.getElementById('vertex-tooltip');
     
 
     // API Keys
@@ -47,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const aspectRatioSelect = document.getElementById('aspect_ratio');
     const personGenerationSelect = document.getElementById('person_generation');
 
-    const vertexAiOptionsContainer = document.getElementById('vertex-ai-options-container');
+
 
     // API Constants
     const OPENAI_API_KEY_NAME = 'openai_api_key';
@@ -98,9 +100,9 @@ document.addEventListener('DOMContentLoaded', () => {
             apiEndpoint: OPENAI_API_ENDPOINT
         },
         
-        // Google Imagen Models
+        // Google Imagen (Gemini API) Model
         "imagen-3.0-generate-002": {
-            provider: "google",
+            provider: "google", // Corresponds to the "Google Imagen" radio button
             sizes: [], // Controlled by aspect ratio instead
             qualities: [], // Not applicable
             maxN: 4, // Google Imagen supports 1-4 images
@@ -112,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
             supportsAspectRatio: true,
             supportsPersonGeneration: true,
             responseFormat: 'b64_json',
-            apiEndpoint: GOOGLE_IMAGEN_API_ENDPOINT
+            apiEndpoint: GOOGLE_IMAGEN_API_ENDPOINT // Gemini API endpoint
         }
     };
 
@@ -120,58 +122,56 @@ document.addEventListener('DOMContentLoaded', () => {
     function updateProviderUI(selectedProvider) {
         console.log(`Updating UI for provider: ${selectedProvider}`);
         
-        // Show/hide API key sections and Vertex options
+        // Show/hide API key sections based on provider
         openaiKeySection.style.display = selectedProvider === 'openai' ? 'block' : 'none';
         googleKeySection.style.display = selectedProvider === 'google' ? 'block' : 'none';
-        vertexAiOptionsContainer.style.display = selectedProvider === 'vertex-ai' ? 'block' : 'none';
+        // Note: Vertex AI is disabled, so no specific key section handling needed here.
 
-        // Enable/disable generate button and clear status
-        if (selectedProvider === 'vertex-ai') {
-            generateButton.disabled = true;
-            generateButton.textContent = 'Generate Image (Vertex AI N/A)';
-            statusMessage.textContent = 'Vertex AI provider selected (UI Only - Generation Disabled).';
-            statusMessage.style.color = 'orange';
-            modelSelect.innerHTML = '<option value="">-- Vertex AI Models Not Implemented --</option>'; // Clear models
-            modelSelect.disabled = true;
-            // Hide all standard model options
-            document.querySelectorAll('.options .option-item').forEach(el => el.style.display = 'none');
-        } else {
-            generateButton.disabled = false;
-            generateButton.textContent = 'Generate Image';
-            statusMessage.textContent = ''; // Clear status message
-            modelSelect.disabled = false;
+        // Enable/disable generate button
+        // The button should be enabled unless a disabled provider is somehow selected
+        const selectedProviderInput = document.querySelector(`input[name="provider"][value="${selectedProvider}"]`);
+        generateButton.disabled = selectedProviderInput?.disabled || false;
+        generateButton.textContent = 'Generate Image';
+        if (generateButton.disabled) {
+             generateButton.textContent = 'Generate Image (Provider N/A)';
+        }
+        
+        // Clear status message
+        statusMessage.textContent = ''; 
+        modelSelect.disabled = false;
 
-            // Filter and show only models for the selected provider (OpenAI or Google)
-            const options = modelSelect.querySelectorAll('option');
-            let firstVisibleOption = null;
-            modelSelect.innerHTML = ''; // Clear previous options before adding new ones
+        // Filter and show only models for the selected provider
+        let firstVisibleOption = null;
+        modelSelect.innerHTML = ''; // Clear previous options before adding new ones
 
-            Object.keys(modelOptions).forEach(modelName => {
-                const modelConfig = modelOptions[modelName];
-                if (modelConfig.provider === selectedProvider) {
-                    const option = document.createElement('option');
-                    option.value = modelName;
-                    option.textContent = modelName;
-                    // Add back classes if needed, e.g., for Google models
-                    if (selectedProvider === 'google') {
-                         option.classList.add('google-model');
-                    }
-                    modelSelect.appendChild(option);
-                    if (!firstVisibleOption) {
-                        firstVisibleOption = option;
-                    }
+        Object.keys(modelOptions).forEach(modelName => {
+            const modelConfig = modelOptions[modelName];
+            if (modelConfig.provider === selectedProvider) {
+                const option = document.createElement('option');
+                option.value = modelName;
+                option.textContent = modelName;
+                // Add class for Google models if needed (for potential future styling)
+                if (selectedProvider === 'google') {
+                     option.classList.add('google-model');
                 }
-            });
-
-            // Select the first visible option and update UI
-            if (firstVisibleOption) {
-                modelSelect.value = firstVisibleOption.value;
-                updateOptionsUI(firstVisibleOption.value);
-            } else {
-                 modelSelect.innerHTML = '<option value="">-- No models available --</option>';
-                 // Hide all standard model options if no models found
-                 document.querySelectorAll('.options .option-item').forEach(el => el.style.display = 'none');
+                modelSelect.appendChild(option);
+                if (!firstVisibleOption) {
+                    firstVisibleOption = option;
+                }
             }
+        });
+
+        // Select the first visible option and update UI
+        if (firstVisibleOption) {
+            modelSelect.value = firstVisibleOption.value;
+            updateOptionsUI(firstVisibleOption.value);
+        } else {
+             // This case should only happen if a provider has no models defined
+             // or if the disabled Vertex provider is somehow selected.
+             modelSelect.innerHTML = '<option value="">-- No models available --</option>';
+             modelSelect.disabled = true;
+             // Hide all standard model options
+             document.querySelectorAll('.options .option-item').forEach(el => el.style.display = 'none');
         }
     }
 
@@ -319,6 +319,7 @@ document.addEventListener('DOMContentLoaded', () => {
     addTooltipListeners(openaiKeyTooltipTrigger, openaiKeyTooltip);
     addTooltipListeners(googleKeyTooltipTrigger, googleKeyTooltip);
     addTooltipListeners(adobeTooltipTrigger, adobeTooltip); // Apply to Adobe too for consistency
+    addTooltipListeners(vertexTooltipTrigger, vertexTooltip);
 
 
     

--- a/script.js
+++ b/script.js
@@ -46,10 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const googleImagenOptions = document.querySelectorAll('.google-imagen-option');
     const aspectRatioSelect = document.getElementById('aspect_ratio');
     const personGenerationSelect = document.getElementById('person_generation');
-    const negativePromptInput = document.getElementById('negative_prompt');
-    const seedInput = document.getElementById('seed');
-    const guidanceScaleInput = document.getElementById('guidance_scale');
-    const stylePresetSelect = document.getElementById('style_preset');
+
 
     // API Constants
     const OPENAI_API_KEY_NAME = 'openai_api_key';
@@ -563,26 +560,6 @@ document.addEventListener('DOMContentLoaded', () => {
             requestBody.parameters.personGeneration = personGenerationSelect.value;
         }
 
-        // Add negative prompt if provided
-        const negativePrompt = negativePromptInput.value.trim();
-        if (negativePrompt) {
-            requestBody.parameters.negativePrompt = negativePrompt;
-        }
-
-        // Add seed if provided
-        const seed = parseInt(seedInput.value);
-        if (!isNaN(seed)) {
-            requestBody.parameters.seed = seed;
-        }
-
-        // Add guidance scale (always include, use default from input)
-        requestBody.parameters.guidanceScale = parseFloat(guidanceScaleInput.value) || 7.0;
-
-        // Add style preset if selected
-        const stylePreset = stylePresetSelect.value;
-        if (stylePreset) {
-            requestBody.parameters.stylePreset = stylePreset;
-        }
 
         console.log('Sending request to Google Imagen:', JSON.stringify(requestBody, null, 2));
 

--- a/style.css
+++ b/style.css
@@ -117,6 +117,11 @@ small {
     margin-top: 10px;
 }
 
+
+.tooltip a {
+    color: #fff; /* Make links white inside tooltips */
+    text-decoration: underline; /* Keep underline for clarity */
+}
 #status-message {
     margin-bottom: 15px;
     font-weight: bold;
@@ -178,6 +183,8 @@ small {
     margin-bottom: 20px;
 }
 
+
+
 .provider-option {
     display: flex;
     align-items: center;
@@ -188,6 +195,11 @@ small {
     cursor: pointer;
 }
 
+
+#api-key-section label {
+    position: relative; /* Anchor for the absolute positioned tooltip */
+    display: inline-block; /* Ensure label and icon stay together */
+}
 .provider-option:hover {
     background-color: #f0f0f0;
 }
@@ -221,6 +233,7 @@ small {
     max-width: 250px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     top: 100%;
+    word-wrap: break-word; /* Allow long text/links to wrap */
     left: 0;
     margin-top: 5px;
 }


### PR DESCRIPTION
*   Adds tooltips next to API key inputs (OpenAI, Google Imagen) with links to get keys.
*   Adds tooltips to disabled providers (Adobe Firefly, Google Vertex AI) explaining their status.
*   Improves tooltip hover behavior to allow clicking links within the tooltip.
*   Refines the "Google Imagen" provider to use the Gemini API endpoint and only show supported parameters (`aspectRatio`, `personGeneration`, `numberOfImages`).
*   Adds a disabled placeholder for the "Google Vertex AI" provider, removing non-functional UI elements.
*   Updates the description for the "Number of Images (n)" control to dynamically reflect the limits of the selected model.
*   Updates `plan.md` to reflect the current state and future considerations for Vertex AI.